### PR TITLE
Grayscale

### DIFF
--- a/ocr4all_helpers/lib/nlbin.py
+++ b/ocr4all_helpers/lib/nlbin.py
@@ -58,9 +58,9 @@ def adaptive_binarize(image, threshold=0.5, zoom=0.5, perc=80, range=20):
     flat -= lo
     flat /= (hi-lo)
     flat = np.clip(flat, 0, 1)
-    bin = 1*(flat>threshold)
+    binary = 1*(flat>threshold)
     del flat
-    return bin.astype(bool)
+    return binary
 
 def estimate_thresholds(flat, bignore=0.1, escale=1.0, lo=5, hi=90):
     '''# estimate low and high thresholds

--- a/ocr4all_helpers/lib/nlbin.py
+++ b/ocr4all_helpers/lib/nlbin.py
@@ -7,7 +7,8 @@
 # dependencies like matplotlib.
 
 import numpy as np
-from scipy.ndimage import filters, interpolation
+from scipy.ndimage import filters, interpolation, morphology
+from scipy import stats
 from PIL import Image
 
 
@@ -41,7 +42,53 @@ def estimate_skew_angle(image, angles):
         return 0
         
 
-def adaptive_binarize(image, zoom=0.5, perc=80, range=20, debug=0):
+def adaptive_binarize(image, threshold=0.5, zoom=0.5, perc=80, range=20):
+    # check whether the image is already effectively binarized
+    extreme = (np.sum(image<0.05)+np.sum(image>0.95))*1.0/np.prod(image.shape)
+    if extreme>0.95:
+        flat = image.astype(np.float64)
+    else:
+        # if not, we need to flatten it by estimating the local whitelevel
+        flat = estimate_local_whitelevel(image, zoom, perc, range).astype(np.float64)
+        del image
+
+    # estimate low and high thresholds
+    lo, hi = estimate_thresholds(flat)
+    # rescale the image to get the gray scale image
+    flat -= lo
+    flat /= (hi-lo)
+    flat = np.clip(flat, 0, 1)
+    bin = 1*(flat>threshold)
+    del flat
+    return bin.astype(bool)
+
+def estimate_thresholds(flat, bignore=0.1, escale=1.0, lo=5, hi=90):
+    '''# estimate low and high thresholds
+    ignore this much of the border for threshold estimation, default: %(default)s
+    scale for estimating a mask over the text region, default: %(default)s
+    lo percentile for black estimation, default: %(default)s
+    hi percentile for white estimation, default: %(default)s
+    '''
+    d0,d1 = flat.shape
+    o0,o1 = int(bignore*d0),int(bignore*d1)
+    est = flat[o0:d0-o0,o1:d1-o1]
+    if escale>0:
+        # by default, we use only regions that contain
+        # significant variance; this makes the percentile
+        # based low and high estimates more reliable
+        e = escale
+        v = est-filters.gaussian_filter(est,e*20.0)
+        v = filters.gaussian_filter(v**2,e*20.0)**0.5
+        v = (v>0.3*np.amax(v))
+        v = morphology.binary_dilation(v,structure=np.ones((int(e*50),1)))
+        v = morphology.binary_dilation(v,structure=np.ones((1,int(e*50))))
+        est = est[v]
+    lo = stats.scoreatpercentile(est.ravel(),lo)
+    hi = stats.scoreatpercentile(est.ravel(),hi)
+    del est
+    return lo, hi
+
+def estimate_local_whitelevel(image, zoom=0.5, perc=80, range=20):
     '''
     Flatten it by estimating the local whitelevel
     zoom for page background estimation, smaller=faster, default: %(default)s
@@ -56,4 +103,3 @@ def adaptive_binarize(image, zoom=0.5, perc=80, range=20, debug=0):
     flat = np.clip(image[:w, :h]-m[:w, :h]+1, 0, 1)
     del m
     return flat
-

--- a/ocr4all_helpers/pagelineseg.py
+++ b/ocr4all_helpers/pagelineseg.py
@@ -225,7 +225,6 @@ def segment(im, scale=None,
 
     if not scale:
         scale = pseg.estimate_scale(binary)
-    s_print(scale, binary.shape, np.min(binary), np.max(binary))
     if scale < minscale:
         s_print_error("scale ({}) less than --minscale; skipping".format(scale))
         return
@@ -367,7 +366,7 @@ def pagexmllineseg(xmlfile, imgpath,
         if cropped is not None:
             colors = cropped.getcolors(2)
             if not (colors is not None and len(colors) == 2):
-                cropped = Image.fromarray(nlbin.adaptive_binarize(np.array(cropped)))
+                cropped = Image.fromarray(nlbin.adaptive_binarize(np.array(cropped)).astype(np.uint8))
             if coordmap[c]["type"] == "drop-capital":
                 lines = [1]
             else:
@@ -592,7 +591,6 @@ def cli():
                         )
                     
     args = parser.parse_args()
-    s_print(args)
 
     with open(args.DATASET, 'r') as data_file:
         dataset = json.load(data_file)

--- a/ocr4all_helpers/pagelineseg.py
+++ b/ocr4all_helpers/pagelineseg.py
@@ -225,6 +225,7 @@ def segment(im, scale=None,
 
     if not scale:
         scale = pseg.estimate_scale(binary)
+    s_print(scale, binary.shape, np.min(binary), np.max(binary))
     if scale < minscale:
         s_print_error("scale ({}) less than --minscale; skipping".format(scale))
         return
@@ -366,10 +367,7 @@ def pagexmllineseg(xmlfile, imgpath,
         if cropped is not None:
             colors = cropped.getcolors(2)
             if not (colors is not None and len(colors) == 2):
-                try:
-                    cropped = nlbin.adaptive_binarize(cropped)
-                except SystemError:
-                    continue
+                cropped = Image.fromarray(nlbin.adaptive_binarize(np.array(cropped)))
             if coordmap[c]["type"] == "drop-capital":
                 lines = [1]
             else:
@@ -594,6 +592,7 @@ def cli():
                         )
                     
     args = parser.parse_args()
+    s_print(args)
 
     with open(args.DATASET, 'r') as data_file:
         dataset = json.load(data_file)

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='ocr4all_helpers',
-      version='0.2d1',
+      version='0.2.2',
       description='Different python scripts used in the OCR4all workflow.',
       url='https://github.com/OCR4all/OCR4all_helper-scripts',
       author='Nico Balbach',


### PR DESCRIPTION
Fix problem with converting bool numpy array to PIL image.

In some PIL versions the conversion seems to silently break and result in an scrambled image.