### PR TITLE
add workaround for skip empty gt parameter

### DIFF
--- a/ocr4all_helper_scripts/cli/calamari_eval_wrapper.py
+++ b/ocr4all_helper_scripts/cli/calamari_eval_wrapper.py
@@ -17,7 +17,7 @@ def calamari_eval_cli(files, num_threads, n_confusions, skip_empty_gt):
     # Necessary because calamari-eval progress bars destroy OCR4all console output
     with contextlib.redirect_stdout(outfile):
         calamari_eval_helper.prepare_filesystem()
-        calamari_eval_helper.save_eval_files(files)
+        calamari_eval_helper.save_eval_files(files, skip_empty_gt)
         calamari_eval_helper.run_eval(n_confusions, skip_empty_gt, num_threads)
         calamari_eval_helper.cleanup()
     with Path(outfile_name).open("r") as fp:

--- a/ocr4all_helper_scripts/helpers/calamari_eval_helper.py
+++ b/ocr4all_helper_scripts/helpers/calamari_eval_helper.py
@@ -16,7 +16,7 @@ def prepare_filesystem():
         EVAL_DIR.mkdir(parents=True, exist_ok=True)
 
 
-def get_text_content(file: str) -> Tuple[List[str], List[str]]:
+def get_text_content(file: str, skip_empty_gt: bool) -> Tuple[List[str], List[str]]:
     gt, pred = [], []
 
     root = etree.parse(file).getroot()
@@ -28,6 +28,7 @@ def get_text_content(file: str) -> Tuple[List[str], List[str]]:
         if len(gt_equiv) == 1:
             gt.append("".join(gt_equiv[0].find("./{*}Unicode").itertext()))
         else:
+            if skip_empty_gt: continue
             gt.append("")
 
         if len(pred_equiv) == 1:
@@ -38,9 +39,9 @@ def get_text_content(file: str) -> Tuple[List[str], List[str]]:
     return gt, pred
 
 
-def save_eval_files(files: List[str]):
+def save_eval_files(files: List[str], skip_empty_gt: bool):
     for file in files:
-        gt, pred = get_text_content(file)
+        gt, pred = get_text_content(file, skip_empty_gt)
 
         with Path(EVAL_DIR, f"{Path(file).name.split('.')[0]}.gt.txt").open("w") as gtfile:
             gtfile.write("\n".join(gt))


### PR DESCRIPTION
Workaround for the skip empty gt parameter. Can most likely be removed after updating the calamari version in the docker image (though it shouldn't do any harm to just keep it there as it mimics the behavior anyways)